### PR TITLE
Ensure optional-dependencies use PEP 508 identifiers

### DIFF
--- a/src/validate_pyproject/plugins/setuptools.schema.json
+++ b/src/validate_pyproject/plugins/setuptools.schema.json
@@ -203,6 +203,8 @@
         "entry-points": {"$ref": "#/definitions/file-directive"},
         "optional-dependencies": {
           "type": "object",
+          "propertyNames": {"format": "pep508-identifier"},
+          "additionalProperties": false,
           "patternProperties": {".+": {"$ref": "#/definitions/file-directive"}}
         },
         "readme": {

--- a/tests/invalid-examples/pretend-setuptools/dependencies/invalid-extra-name.errors.txt
+++ b/tests/invalid-examples/pretend-setuptools/dependencies/invalid-extra-name.errors.txt
@@ -1,0 +1,3 @@
+`tool.setuptools.dynamic.optional-dependencies` keys must be named by:
+
+    {format: 'pep508-identifier'}

--- a/tests/invalid-examples/pretend-setuptools/dependencies/invalid-extra-name.toml
+++ b/tests/invalid-examples/pretend-setuptools/dependencies/invalid-extra-name.toml
@@ -1,0 +1,7 @@
+[project]
+name = "myproj"
+version = "42"
+dynamic = ["optional-dependencies"]
+
+[tool.setuptools.dynamic.optional-dependencies."non pep508 compliant"]
+file = "extra.txt"


### PR DESCRIPTION
Hi @akx thank you very much for the PR.

I think we should ensure the name of the optional group match PEP 508 grammar here.

This is specified via PEP 621: https://peps.python.org/pep-0621/#dependencies-optional-dependencies.
I am suggesting the following changes.